### PR TITLE
make it installable with current Firefox versions

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -4,7 +4,7 @@
   <Description about="urn:mozilla:install-manifest">
     <em:id>{a76cd07b-f0d7-4ef9-9566-8faef6e290e4}</em:id>
     <em:name>Bookmark All</em:name>
-    <em:version>1.3.2</em:version>
+    <em:version>1.3.3</em:version>
     <em:description>Bookmark all opening tabs quickly without any dialog.</em:description>
     <em:creator>Kyo Nagashima</em:creator>
     <em:homepageURL>http://hail2u.github.com/firefox-addons.html#bookmark-all</em:homepageURL>
@@ -14,7 +14,7 @@
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>3.0</em:minVersion>
-        <em:maxVersion>4.0.*</em:maxVersion>
+        <em:maxVersion>8.0.*</em:maxVersion>
       </Description>
     </em:targetApplication>
   </Description>


### PR DESCRIPTION
If you're still out there and listening, perhaps you can pull this humble little change that makes bookmark-all work with current versions of Firefox.
